### PR TITLE
Slack enterprise channel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This is small application designed to keep me informed about the latest news and
     - [x] Support receiver to remote write metrics to Prometheus
     - [x] Visualize to dashboard
   - [x] Slack Incoming Webhook
+  - [x] Slack Enterprise channel (bot token + channel ID)
 
 ## Get started
 

--- a/docs/how-to-configure.md
+++ b/docs/how-to-configure.md
@@ -67,6 +67,8 @@ categories:
     slack:
       enabled: <boolean>
       webhookUrl: <string>
+      botToken: <string> # optional, required with channelId for Slack enterprise channel
+      channelId: <string> # optional, required with botToken for Slack enterprise channel
     feeds: [list of key value> | default = []]
 ```
 
@@ -101,6 +103,8 @@ categories:
     slack:
       enabled: true
       webhookUrl: ${SLACK_WEBHOOK_URL}
+      botToken: ${SLACK_BOT_TOKEN}
+      channelId: ${SLACK_TECHNOLOGY_CHANNEL_ID}
     feeds:
       - name: Kubernetes Blog
         url: https://kubernetes.io/feed.xml

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -64,8 +64,10 @@ type Category struct {
 		} `yaml:"baicAuth"`
 	} `yaml:"prometheus"`
 	Slack struct {
-		Enabled       bool   `yaml:"enabled"`
-		WebhookUrlUrl string `yaml:"webhookUrl"`
+		Enabled    bool   `yaml:"enabled"`
+		WebhookURL string `yaml:"webhookUrl"`
+		BotToken   string `yaml:"botToken"`
+		ChannelID  string `yaml:"channelId"`
 	} `yaml:"slack"`
 	Feed []Feed `yaml:"feeds"`
 }

--- a/pkg/receiver/main.go
+++ b/pkg/receiver/main.go
@@ -34,7 +34,9 @@ func SendNotification(config *config.Category, category string, title string, li
 	if config.Slack.Enabled {
 		logger.Debugf("Slack is enabled, sending %s.\n", link)
 		sendSlackMessage(
-			config.Slack.WebhookUrlUrl,
+			config.Slack.WebhookURL,
+			config.Slack.BotToken,
+			config.Slack.ChannelID,
 			title,
 			link,
 		)

--- a/pkg/receiver/slack.go
+++ b/pkg/receiver/slack.go
@@ -11,46 +11,127 @@ import (
 	"daily-news-feed/pkg/util"
 )
 
-func sendSlackMessage(webhookURL string, title string, url string) error {
+const slackChatPostMessageURL = "https://slack.com/api/chat.postMessage"
+
+type slackChatPostMessageRequest struct {
+	Channel string `json:"channel"`
+	Text    string `json:"text"`
+}
+
+type slackChatPostMessageResponse struct {
+	OK    bool   `json:"ok"`
+	Error string `json:"error"`
+}
+
+func sendSlackMessage(webhookURL string, botToken string, channelID string, title string, url string) error {
 	logger := util.Logger()
+
+	message := fmt.Sprintf("%s\n%s", title, url)
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	if botToken != "" || channelID != "" {
+		if botToken == "" || channelID == "" {
+			logger.Error("Slack bot token and channel ID must both be set to use Slack API")
+		} else {
+			if err := sendSlackMessageByAPI(client, botToken, channelID, message); err == nil {
+				logger.Debugf("Message sent to Slack channel successfully: %s", title)
+				return nil
+			} else {
+				logger.Errorf("Failed to send message using Slack API: %v", err)
+				if webhookURL == "" {
+					return err
+				}
+				logger.Warn("Falling back to Slack incoming webhook")
+			}
+		}
+	}
+
 	if webhookURL == "" {
 		logger.Error("Slack webhook URL is not set")
 		return nil
 	}
 
-	message := fmt.Sprintf("%s\n%s", title, url)
-	payload := map[string]string{"text": message}
+	if err := sendSlackMessageByWebhook(client, webhookURL, message); err != nil {
+		logger.Errorf("Failed to send message using Slack webhook: %v", err)
+		return err
+	}
 
+	logger.Debugf("Message sent to Slack successfully: %s", title)
+	return nil
+}
+
+func sendSlackMessageByWebhook(client *http.Client, webhookURL string, message string) error {
+	payload := map[string]string{"text": message}
 	jsonStr, err := json.Marshal(payload)
 	if err != nil {
-		logger.Errorf("Failed to marshal payload: %v", err)
-		return err
+		return fmt.Errorf("marshal Slack webhook payload: %w", err)
 	}
 
 	req, err := http.NewRequest(http.MethodPost, webhookURL, bytes.NewBuffer(jsonStr))
 	if err != nil {
-		logger.Errorf("Failed to create request: %v", err)
-		return err
+		return fmt.Errorf("create Slack webhook request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	client := http.Client{
-		Timeout: 5 * time.Second,
-	}
-
 	res, err := client.Do(req)
 	if err != nil {
-		logger.Errorf("Failed to send request: %v", err)
-		return err
+		return fmt.Errorf("send Slack webhook request: %w", err)
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(res.Body)
-		logger.Errorf("Unexpected status code %d: %s", res.StatusCode, body)
-		return err
+		return fmt.Errorf("unexpected Slack webhook status code %d: %s", res.StatusCode, body)
 	}
 
-	logger.Debugf("Message sent to Slack successfully: %s", title)
+	return nil
+}
+
+func sendSlackMessageByAPI(client *http.Client, botToken string, channelID string, message string) error {
+	payload := slackChatPostMessageRequest{
+		Channel: channelID,
+		Text:    message,
+	}
+	jsonStr, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal Slack API payload: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, slackChatPostMessageURL, bytes.NewBuffer(jsonStr))
+	if err != nil {
+		return fmt.Errorf("create Slack API request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", botToken))
+
+	res, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send Slack API request: %w", err)
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return fmt.Errorf("read Slack API response: %w", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected Slack API status code %d: %s", res.StatusCode, body)
+	}
+
+	var response slackChatPostMessageResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return fmt.Errorf("unmarshal Slack API response: %w", err)
+	}
+
+	if !response.OK {
+		if response.Error == "" {
+			response.Error = "unknown_error"
+		}
+		return fmt.Errorf("Slack API error: %s", response.Error)
+	}
+
 	return nil
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add support for Slack enterprise channels using bot tokens and channel IDs.

The existing Slack integration only supported incoming webhooks, which is often insufficient for enterprise setups. This change introduces an alternative method using the Slack Web API (`chat.postMessage`) when a bot token and channel ID are provided, while maintaining backward compatibility for existing webhook configurations.

---
<p><a href="https://cursor.com/agents/bc-b44d7d35-d100-4315-8316-48c17bfa3bb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b44d7d35-d100-4315-8316-48c17bfa3bb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->